### PR TITLE
Extend plugin with ability to modify document

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -61,3 +61,6 @@ tests:
     - -with-rtsopts=-N
     dependencies:
     - frost
+    - QuickCheck
+    - hspec
+    - raw-strings-qq

--- a/src/Frost.hs
+++ b/src/Frost.hs
@@ -12,7 +12,7 @@ data DynamicError = DynamicError String deriving Show
 generateDocs :: ( Member (Input Pandoc) r
                 , Member (Output Pandoc) r
                 , Member (Error DynamicError) r
-                ) => (Pandoc -> Sem r (Either DynamicError Pandoc)) -> Sem r ()
-generateDocs  transform = input >>= transform >>= either throw output
+                ) => (Pandoc -> Sem r Pandoc) -> Sem r ()
+generateDocs  transform = input >>= transform >>= output
 
 

--- a/src/Frost.hs
+++ b/src/Frost.hs
@@ -7,7 +7,8 @@ import Polysemy.Output
 import Polysemy.Error
 import Text.Pandoc
 
-data DynamicError = DynamicError String deriving Show
+data DynamicError = PluginNotAvailable String | DynamicError String
+  deriving (Eq, Show)
 
 generateDocs :: ( Member (Input Pandoc) r
                 , Member (Output Pandoc) r

--- a/src/Frost/DefaultsMandatoryPlugin.hs
+++ b/src/Frost/DefaultsMandatoryPlugin.hs
@@ -7,7 +7,7 @@ import PolysemyContrib
 import Data.Map.Strict
 
 defaultsMandatoryPlugin :: Plugin r
-defaultsMandatoryPlugin = Plugin "meta.defaults" (return []) atm
+defaultsMandatoryPlugin = Plugin "meta.defaults" (\_ -> return []) atm
   where
     atm  = return . Meta . insertTitle . unMeta
     insertTitle = insert "title" (MetaString $ "Documentation")

--- a/src/Frost/DefaultsMandatoryPlugin.hs
+++ b/src/Frost/DefaultsMandatoryPlugin.hs
@@ -7,7 +7,7 @@ import PolysemyContrib
 import Data.Map.Strict
 
 defaultsMandatoryPlugin :: Plugin r
-defaultsMandatoryPlugin = Plugin atm
+defaultsMandatoryPlugin = Plugin "meta.defaults" (return []) atm
   where
     atm  = return . Meta . insertTitle . unMeta
     insertTitle = insert "title" (MetaString $ "Documentation")

--- a/src/Frost/Plugin.hs
+++ b/src/Frost/Plugin.hs
@@ -4,5 +4,7 @@ import Text.Pandoc
 import Polysemy
 
 data Plugin r = Plugin {
+                     name :: String,
+                     substitute :: Sem r [Block],
                      addToMeta :: Meta -> Sem r Meta
                      }

--- a/src/Frost/Plugin.hs
+++ b/src/Frost/Plugin.hs
@@ -4,7 +4,7 @@ import Text.Pandoc
 import Polysemy
 
 data Plugin r = Plugin {
-                     name :: String,
-                     substitute :: Sem r [Block],
+                     pluginName :: String,
+                     substitute :: String -> Sem r [Block],
                      addToMeta :: Meta -> Sem r Meta
                      }

--- a/src/Frost/Plugins.hs
+++ b/src/Frost/Plugins.hs
@@ -7,18 +7,19 @@ import Frost.DefaultsMandatoryPlugin
 import Data.List (find)
 import Control.Monad
 import Polysemy
+import Polysemy.Error
 import PolysemyContrib
 import Text.Pandoc
 import Text.Pandoc.Extensions
 import Data.Map.Strict
 import Data.Traversable
 
-transform :: [Plugin r] -> Pandoc -> Sem r (Either DynamicError Pandoc)
+transform :: Member (Error DynamicError) r => [Plugin r] -> Pandoc -> Sem r Pandoc
 transform plugins (Pandoc meta blocks) = do
   let plugin = (head plugins) -- TODO LOL, use all plugins, not one
   newMeta <- addToMeta plugin meta
   newBlocks <- traverse (extractFrostBlocks plugins) blocks
-  return $ Right (Pandoc newMeta (join newBlocks))
+  return $ Pandoc newMeta (join newBlocks)
 
   where
     extractFrostBlocks plugins = (\case

--- a/src/Frost/Plugins.hs
+++ b/src/Frost/Plugins.hs
@@ -22,12 +22,13 @@ transform plugins (Pandoc meta blocks) = do
   return $ Pandoc newMeta (join newBlocks)
 
   where
+    extractFrostBlocks :: Member (Error DynamicError) r => [Plugin r] -> Block -> Sem r [Block]
     extractFrostBlocks plugins = (\case
         CodeBlock ("",[name],[]) content -> do
           let maybePlugin = find (\p -> "frost:" ++ pluginName p == name) plugins
           case maybePlugin of
             Just plugin ->  substitute plugin content
-            Nothing -> return [HorizontalRule]
+            Nothing -> throw $ PluginNotAvailable name
         otherwise -> return [otherwise])
 
 plugins :: Member SystemEffect r => [Plugin r]

--- a/src/Frost/TimestampPlugin.hs
+++ b/src/Frost/TimestampPlugin.hs
@@ -7,7 +7,7 @@ import PolysemyContrib
 import Data.Map.Strict
 
 timestampPlugin :: Member SystemEffect r => Plugin r
-timestampPlugin = Plugin atm
+timestampPlugin = Plugin "timestamp:meta" (return []) atm
   where
     atm :: Member SystemEffect r =>  Meta -> Sem r Meta
     atm meta = do

--- a/src/Frost/TimestampPlugin.hs
+++ b/src/Frost/TimestampPlugin.hs
@@ -7,7 +7,7 @@ import PolysemyContrib
 import Data.Map.Strict
 
 timestampPlugin :: Member SystemEffect r => Plugin r
-timestampPlugin = Plugin "timestamp:meta" (return []) atm
+timestampPlugin = Plugin "timestamp:meta" (\_ -> return []) atm
   where
     atm :: Member SystemEffect r =>  Meta -> Sem r Meta
     atm meta = do

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -1,2 +1,1 @@
-main :: IO ()
-main = putStrLn "Test suite not yet implemented"
+{-# OPTIONS_GHC -F -pgmF hspec-discover #-}

--- a/test/TransformSpec.hs
+++ b/test/TransformSpec.hs
@@ -1,0 +1,51 @@
+{-# LANGUAGE QuasiQuotes #-}
+module TransformSpec where
+
+import Frost
+import Frost.Plugin
+import Frost.Plugins (transform)
+
+import Text.Pandoc
+import Data.Function ((&))
+import Polysemy
+import Polysemy.Input
+import Polysemy.Output
+import qualified Data.Text as T
+import Test.Hspec
+import Text.RawString.QQ
+
+
+purgePlugin :: Plugin r
+purgePlugin = Plugin { pluginName = "null"
+                    , substitute = \_ -> return []
+                    , addToMeta = \m -> return nullMeta
+                    }
+
+textPlugin :: String -> Plugin r
+textPlugin text= Plugin { pluginName = "text:insert"
+                    , substitute = \_ -> return [Plain [Str text]]
+                    , addToMeta = \m -> return nullMeta
+                    }
+
+spec :: Spec
+spec =
+  describe "Frost.Plugins transform" $ do
+    it "should keep document as is, if no frost code blocks in it" $ do
+      -- given
+      let blocks = [ HorizontalRule
+                   , Plain [Str "test"]]
+      let pandoc = Pandoc nullMeta blocks
+      -- when
+      let Right(transformed) =  run $ transform [purgePlugin] pandoc
+      -- then
+      transformed `shouldBe` pandoc
+    it "should substitute frost code blocks with content from plugin" $ do
+      -- given
+      let blocks = [ HorizontalRule
+                   , CodeBlock ("",["frost:text:insert"],[]) ""]
+      let pandoc = Pandoc nullMeta blocks
+      -- when
+      let Right(Pandoc _ transformedBlocks) =  run $ transform [textPlugin "hello world!"] pandoc
+      -- then
+      transformedBlocks `shouldBe` [ HorizontalRule
+                                   , Plain [Str "hello world!"]]

--- a/test/TransformSpec.hs
+++ b/test/TransformSpec.hs
@@ -8,8 +8,7 @@ import Frost.Plugins (transform)
 import Text.Pandoc
 import Data.Function ((&))
 import Polysemy
-import Polysemy.Input
-import Polysemy.Output
+import Polysemy.Error
 import qualified Data.Text as T
 import Test.Hspec
 import Text.RawString.QQ
@@ -42,7 +41,7 @@ spec =
                    , Plain [Str "test"]]
       let pandoc = Pandoc nullMeta blocks
       -- when
-      let Right(transformed) =  run $ transform [purgePlugin] pandoc
+      let Right(transformed) =  run $ runError $ transform [purgePlugin] pandoc
       -- then
       transformed `shouldBe` pandoc
 
@@ -52,7 +51,7 @@ spec =
                    , CodeBlock ("",["frost:text:insert"],[]) ""]
       let pandoc = Pandoc nullMeta blocks
       -- when
-      let Right(Pandoc _ transformedBlocks) =  run $ transform [textPlugin "hello world!"] pandoc
+      let Right(Pandoc _ transformedBlocks) =  run $ runError $ transform [textPlugin "hello world!"] pandoc
       -- then
       transformedBlocks `shouldBe` [ HorizontalRule
                                    , Plain [Str "hello world!"]]
@@ -65,7 +64,7 @@ spec =
       let pandoc = Pandoc nullMeta blocks
       let plugs = [doublePlugin, textPlugin "hello world!"]
       -- when
-      let Right(Pandoc _ transformedBlocks) =  run $ transform plugs pandoc
+      let Right(Pandoc _ transformedBlocks) =  run $ runError $ transform plugs pandoc
       -- then
       transformedBlocks `shouldBe` [ HorizontalRule
                                    , Plain [Str "hello world!"]

--- a/test/TransformSpec.hs
+++ b/test/TransformSpec.hs
@@ -69,4 +69,13 @@ spec =
       transformedBlocks `shouldBe` [ HorizontalRule
                                    , Plain [Str "hello world!"]
                                    , Plain [Str "4"]]
-
+    it "should stop with error if plugin not found for given frost block" $ do
+      -- given
+      let blocks = [ HorizontalRule
+                  , CodeBlock ("",["frost:text:insert"],[]) ""]
+      let pandoc = Pandoc nullMeta blocks
+      let plugs = [purgePlugin]
+      -- when
+      let Left(error) =  run $ runError $ transform plugs pandoc
+      -- then
+      error `shouldBe` PluginNotAvailable "frost:text:insert"

--- a/test/TransformSpec.hs
+++ b/test/TransformSpec.hs
@@ -27,6 +27,12 @@ textPlugin text= Plugin { pluginName = "text:insert"
                     , addToMeta = \m -> return nullMeta
                     }
 
+doublePlugin ::  Plugin r
+doublePlugin= Plugin { pluginName = "double"
+                    , substitute = \i -> return [Plain [Str $ show $ 2 * read i]]
+                    , addToMeta = \m -> return nullMeta
+                    }
+
 spec :: Spec
 spec =
   describe "Frost.Plugins transform" $ do
@@ -39,6 +45,7 @@ spec =
       let Right(transformed) =  run $ transform [purgePlugin] pandoc
       -- then
       transformed `shouldBe` pandoc
+
     it "should substitute frost code blocks with content from plugin" $ do
       -- given
       let blocks = [ HorizontalRule
@@ -49,3 +56,18 @@ spec =
       -- then
       transformedBlocks `shouldBe` [ HorizontalRule
                                    , Plain [Str "hello world!"]]
+
+    it "should modify document with multiple plugins" $ do
+      -- given
+      let blocks = [ HorizontalRule
+                  , CodeBlock ("",["frost:text:insert"],[]) ""
+                  , CodeBlock ("",["frost:double"],[]) "2"]
+      let pandoc = Pandoc nullMeta blocks
+      let plugs = [doublePlugin, textPlugin "hello world!"]
+      -- when
+      let Right(Pandoc _ transformedBlocks) =  run $ transform plugs pandoc
+      -- then
+      transformedBlocks `shouldBe` [ HorizontalRule
+                                   , Plain [Str "hello world!"]
+                                   , Plain [Str "4"]]
+


### PR DESCRIPTION
Once this PR gets in, `frost` gets full framework to support multiple plugins - In other words we can focus primarily on writing plugins and they will be rendered by `frost`

```
Transform
  Frost.Plugins transform
    should keep document as is, if no frost code blocks in it
    should substitute frost code blocks with content from plugin
    should modify document with multiple plugins
    should stop with error if plugin not found for given frost block
```