### PR TITLE
Two rendering functions

### DIFF
--- a/src/Frost.hs
+++ b/src/Frost.hs
@@ -9,7 +9,8 @@ import Frost.DefaultsMandatoryPlugin
 import Frost.Effects.Git
 import Frost.Effects.Sys
 
-import Data.Foldable
+import Data.Foldable (foldM)
+import Data.Functor ((<&>))
 import Data.List (find)
 import Control.Monad
 import Polysemy
@@ -40,12 +41,12 @@ transform plugins (Pandoc meta blocks) = do
         Para [Code ("",[],[]) name] -> do
           let maybePlugin = find (\p -> "frost:" ++ pluginName p == name) plugins
           case maybePlugin of
-            Just plugin ->  substitute plugin ""
+            Just plugin ->  substitute plugin "" <&> fst
             Nothing -> throw $ PluginNotAvailable name
         CodeBlock ("",[name],[]) content -> do
           let maybePlugin = find (\p -> "frost:" ++ pluginName p == name) plugins
           case maybePlugin of
-            Just plugin ->  substitute plugin content
+            Just plugin ->  substitute plugin content <&> fst
             Nothing -> throw $ PluginNotAvailable name
         otherwise -> return [otherwise])
 

--- a/src/Frost/GitContributorsPlugin.hs
+++ b/src/Frost/GitContributorsPlugin.hs
@@ -11,4 +11,6 @@ import Data.Map.Strict
 gitContributorsPlugin :: Member Git r => Plugin r
 gitContributorsPlugin = justContentPlugin "git:devs" (\_ -> render <$> devsList)
   where
-    render devs = [BulletList $ fmap (\d -> [Plain [Str d]]) devs]
+    render devs = (renderContent devs, renderText devs)
+    renderContent devs = [BulletList $ fmap (\d -> [Plain [Str d]]) devs]
+    renderText = fmap Str

--- a/src/Frost/Plugin.hs
+++ b/src/Frost/Plugin.hs
@@ -5,12 +5,12 @@ import Polysemy
 
 data Plugin r = Plugin {
                      pluginName :: String,
-                     substitute :: String -> Sem r [Block],
+                     substitute :: String -> Sem r ([Block], [Inline]),
                      addToMeta :: Meta -> Sem r Meta
                      }
 
-justContentPlugin :: String -> (String -> Sem r [Block]) -> Plugin r
+justContentPlugin :: String -> (String -> Sem r ([Block], [Inline])) -> Plugin r
 justContentPlugin pluginName substitute = Plugin pluginName substitute return
 
 justMetaPlugin :: String -> (Meta -> Sem r Meta) -> Plugin r
-justMetaPlugin pluginName addToMeta = Plugin pluginName (\_ -> return []) addToMeta
+justMetaPlugin pluginName addToMeta = Plugin pluginName (\_ -> return ([], [])) addToMeta

--- a/src/Frost/TimestampPlugin.hs
+++ b/src/Frost/TimestampPlugin.hs
@@ -18,4 +18,4 @@ timestampMetaPlugin = justMetaPlugin "timestamp:meta" (\meta -> do
 timestampPlugin :: Member Sys r => Plugin r
 timestampPlugin = justContentPlugin "timestamp" (\_ -> currentTime <&> render)
   where
-    render t = [Plain [Str $show t]]
+    render t = ([Plain [Str $ show t]], [Str $ show t])

--- a/test/GitContributorsPluginSpec.hs
+++ b/test/GitContributorsPluginSpec.hs
@@ -19,4 +19,5 @@ spec =
             & runGitPure ["Dev1", "Dev2"]
             & run
       -- then
-      res `shouldBe` [BulletList [ [Plain [Str "Dev1"]], [Plain [Str "Dev2"]]]]
+      fst res `shouldBe` [BulletList [ [Plain [Str "Dev1"]], [Plain [Str "Dev2"]]]]
+      snd res `shouldBe` [Str "Dev1", Str "Dev2"]

--- a/test/TransformSpec.hs
+++ b/test/TransformSpec.hs
@@ -68,6 +68,32 @@ spec =
       transformedBlocks `shouldBe` [ Plain [Str "hello world!"]
                                    , Plain [Str "4"]]
 
+    it "should modify document with multiple plugins" $ do
+      -- given
+      let blocks = [Para [ Str "The"
+                              , Space
+                              , Str "value:"
+                              , Space
+                              , Code ("",[],[]) "frost:text:insert"
+                              , Space
+                              , Code ("",[],[]) "frost:double 5"
+                         ]
+                   ]
+      let pandoc = Pandoc nullMeta blocks
+      let plugs = [doublePlugin, textPlugin "hello world!"]
+      -- when
+      let Right(Pandoc _ transformedBlocks) =  run $ runError $ transform plugs pandoc
+      -- then
+      transformedBlocks `shouldBe` [Para [ Str "The"
+                                         , Space
+                                         , Str "value:"
+                                         , Space
+                                         , Str "hello world!"
+                                         , Space
+                                         , Str "10"
+                                         ]
+                                   ]
+
     it "should modify a document with multiple meta plugins" $ do
       -- given
       let pandoc = Pandoc nullMeta [Null]

--- a/test/TransformSpec.hs
+++ b/test/TransformSpec.hs
@@ -14,15 +14,15 @@ import Test.Hspec
 
 purgePlugin :: Plugin r
 purgePlugin = Plugin { pluginName = "null"
-                     , substitute = \_ -> return []
+                     , substitute = \_ -> return ([], [])
                      , addToMeta = \m -> return nullMeta
                      }
 
 textPlugin :: String -> Plugin r
-textPlugin text = justContentPlugin "text:insert" (\_ -> return [Plain [Str text]])
+textPlugin text = justContentPlugin "text:insert" (\_ -> return ([Plain [Str text]], [Str text]))
 
 doublePlugin ::  Plugin r
-doublePlugin= justContentPlugin "double" (\i -> return [Plain [Str $ show $ 2 * read i]])
+doublePlugin= justContentPlugin "double" (\i -> return ([Plain [Str $ show $ 2 * read i]], [Str $ show $ 2 * read i]))
 
 addEntryMetaPlugin :: String -> String -> Plugin r
 addEntryMetaPlugin key value = justMetaPlugin "meta:plugin" (\meta -> return $ Meta (insert key (MetaString value) ( unMeta meta) ) )


### PR DESCRIPTION
Modify `Plugin` so that it renders both content (`[Block]`) or text (`[Inline]`).

For now  the function is `substitute :: String -> Sem r ([Block], [Inline]),`
in the future hopefully this could be polymorphic and we would let the caller to decide which should be rendered (since rendering might be also expensive).
But for now, this should suffice.